### PR TITLE
rm unnecessary try/catch block around the Ilios client instantiation.

### DIFF
--- a/classes/form/create_sync_job.php
+++ b/classes/form/create_sync_job.php
@@ -76,8 +76,9 @@ class create_sync_job extends moodleform {
             $roleoptions[$role->id] = $role->localname;
         }
 
+        $iliosclient = di::get(ilios::class);
+
         try {
-            $iliosclient = di::get(ilios::class);
             $iliosschools = $iliosclient->get_schools();
             if (!empty($iliosschools)) {
                 $iliosschools = array_column($iliosschools, 'title', 'id');

--- a/classes/task/sync_task.php
+++ b/classes/task/sync_task.php
@@ -77,12 +77,7 @@ class sync_task extends scheduled_task {
             return;
         }
 
-        try {
-            $iliosclient = di::get(ilios::class);
-        } catch (Exception $e) {
-            // Re-throw exception.
-            throw new Exception('ERROR: Failed to instantiate Ilios client.', $e);
-        }
+        $iliosclient = di::get(ilios::class);
 
         // Run enabled each sync job.
         foreach ($syncjobs as $syncjob) {


### PR DESCRIPTION
the only thing that would cause an exception to get thrown in the constructor of the Ilios client class would be emitted out of the Moodle-core `get_config()` method. which would only occur if we tried to read plugin config during system installation. we're not doing this here, so let's get rid of it.

as a positive side-effect, this also eliminates the need to correct the incorrect position of the chained re-thrown exception that's  being passed into the Exception constructor.

while at it, i moved the client instantiation out of the try/catch block in the new sync job form. should make it clearer what we're actually tring to catch there.