### PR TITLE
Cover sync job management and plugin settings UIs with Behat tests

### DIFF
--- a/classes/form/create_sync_job.php
+++ b/classes/form/create_sync_job.php
@@ -26,13 +26,12 @@ namespace tool_ilioscategoryassignment\form;
 
 defined('MOODLE_INTERNAL') || die();
 
-use core\di;
 use core_course_category;
 use Exception;
 use moodle_page;
 use moodleform;
-use tool_ilioscategoryassignment\ilios;
 use tool_ilioscategoryassignment\output\renderer;
+use tool_ilioscategoryassignment\utils;
 
 require_once($CFG->libdir . '/accesslib.php');
 require_once($CFG->libdir . '/formslib.php');
@@ -76,7 +75,7 @@ class create_sync_job extends moodleform {
             $roleoptions[$role->id] = $role->localname;
         }
 
-        $iliosclient = di::get(ilios::class);
+        $iliosclient = utils::get_ilios_client();
 
         try {
             $iliosschools = $iliosclient->get_schools();

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -67,7 +67,7 @@ class renderer extends plugin_renderer_base {
             get_string('iliosschool', 'tool_ilioscategoryassignment'),
             get_string('actions'),
         ];
-        $table->attributes['class'] = 'admintable generaltable';
+        $table->attributes['class'] = 'admintable generaltable tool-ilioscategoryassignment-sync-jobs';
         $data = [];
 
         foreach ($syncjobs as $job) {

--- a/classes/task/sync_task.php
+++ b/classes/task/sync_task.php
@@ -25,7 +25,7 @@
 namespace tool_ilioscategoryassignment\task;
 
 use coding_exception;
-use core\di;
+
 use core\task\scheduled_task;
 use core_course_category;
 use dml_exception;
@@ -34,6 +34,7 @@ use moodle_exception;
 use stdClass;
 use tool_ilioscategoryassignment\ilios;
 use tool_ilioscategoryassignment\sync_job;
+use tool_ilioscategoryassignment\utils;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -77,7 +78,7 @@ class sync_task extends scheduled_task {
             return;
         }
 
-        $iliosclient = di::get(ilios::class);
+        $iliosclient = utils::get_ilios_client();
 
         // Run enabled each sync job.
         foreach ($syncjobs as $syncjob) {

--- a/classes/tests/ilios_backend.php
+++ b/classes/tests/ilios_backend.php
@@ -1,0 +1,94 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mock Ilios backend for Behat tests.
+ *
+ * @package    tool_ilioscategoryassignment
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_ilioscategoryassignment\tests;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * This Guzzle custom handler provides a mock Ilios backend for acceptance testing.
+ *
+ * @package    tool_ilioscategoryassignment
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class ilios_backend {
+
+    /**
+     * @var array A list of mock Ilios school data.
+     */
+    protected array $mockschools;
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        $this->mockschools = [
+            ['id' => 1, 'title' => 'Medicine'],
+            ['id' => 2, 'title' => 'Pharmacy'],
+        ];
+    }
+
+    /**
+     * Responds to the given request with the appropriate response.
+     * @param RequestInterface $request The given request.
+     * @return PromiseInterface A promise resolving to a response object.
+     */
+    public function __invoke(RequestInterface $request): PromiseInterface {
+        $uri = $request->getUri();
+        $path = $uri->getPath();
+
+        // Route by path.
+        $response = match($path) {
+            '/api/v3/schools' => $this->get_all_schools_response(),
+            default => new Response(500),
+        };
+
+        // The response must be wrapped in a promise.
+        // Create one and resolve it immediately.
+        // See https://github.com/guzzle/promises?tab=readme-ov-file#synchronous-wait.
+        $promise = new Promise(function () use (&$promise, $response) {
+            $promise->resolve($response);
+        });
+        $promise->wait(false);
+
+        // Return resolved promise containing the applicable response.
+        return $promise;
+    }
+
+    /**
+     * Returns are mocked response for the schools endpoint on the Ilios API.
+     * @link https://demo.iliosproject.org/api/doc#operations-Schools-get_app_api_schools_getall
+     * @return ResponseInterface
+     */
+    protected function get_all_schools_response(): ResponseInterface {
+        return new Response(200, [], json_encode([
+            'schools' => $this->mockschools,
+        ]));
+    }
+}

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Utility class.
+ *
+ * @package    tool_ilioscategoryassignment
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_ilioscategoryassignment;
+
+use core\di;
+use core\http_client;
+use GuzzleHttp\HandlerStack;
+use tool_ilioscategoryassignment\tests\ilios_backend;
+
+/**
+ * Provides utility methods for this plugin.
+ *
+ * @package    tool_ilioscategoryassignment
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class utils {
+    /**
+     * Returns an Ilios API client.
+     * @return ilios The Ilios API client.
+     */
+    public static function get_ilios_client(): ilios {
+        // ACHTUNG!
+        // If we're running in Behat test mode ONLY, then return a client with a mocked Ilios backend.
+        if (defined('BEHAT_SITE_RUNNING') && get_config('tool_ilioscategoryassignment', 'ilios_mock_backend_enabled')) {
+            $handlerstack = HandlerStack::create(new ilios_backend());
+            $httpclient = new http_client(['handler' => $handlerstack]);
+            return new ilios($httpclient);
+        }
+        // Otherwise, return the container-managed Ilios client instance.
+        return di::get(ilios::class);
+    }
+}

--- a/index.php
+++ b/index.php
@@ -26,6 +26,7 @@ use core\di;
 use core\output\notification;
 use tool_ilioscategoryassignment\ilios;
 use tool_ilioscategoryassignment\sync_job;
+use tool_ilioscategoryassignment\utils;
 
 require_once(__DIR__ . '/../../../config.php');
 
@@ -117,7 +118,7 @@ if (!empty($jobs)) {
 
 try {
     $accesstoken = get_config('tool_ilioscategoryassignment', 'apikey') ?: '';
-    $iliosclient = di::get(ilios::class);
+    $iliosclient = utils::get_ilios_client();
     $iliosschools = $iliosclient->get_schools();
     $iliosschools = array_column($iliosschools, 'title', 'id');
 } catch (Exception $e) {

--- a/tests/behat/behat_tool_ilioscategoryassignment_behat_base.php
+++ b/tests/behat/behat_tool_ilioscategoryassignment_behat_base.php
@@ -1,0 +1,146 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Behat custom step definitions.
+ *
+ * @package tool_ilioscategoryassignment
+ * @copyright The Regents of the University of California
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_ilioscategoryassignment\tests\helper;
+
+require_once(__DIR__.'/../../../../../lib/behat/behat_base.php');
+
+
+/**
+ * Steps definitions for tool_ilioscategoryassignment.
+ *
+ * @package tool_ilioscategoryassignment
+ * @copyright The Regents of the University of California
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_tool_ilioscategoryassignment_behat_base extends behat_base {
+
+    /**
+     * Create and store a valid API access token in the plugin configuration.
+     *
+     * @Then /^a valid Ilios API access token has been configured for tool_ilioscategoryassignment$/
+     */
+    public function a_valid_ilios_api_access_token_has_been_configured_for_tool_ilioscategoryassignment(): void {
+        $accesstoken = helper::create_valid_ilios_api_access_token();
+        set_config('apikey', $accesstoken, 'tool_ilioscategoryassignment');
+    }
+
+    /**
+     * Asserts that the sync job on the given table row is enabled.
+     *
+     * @Then /^the sync job in row (\d+) should be enabled$/
+     * @param string $rownumber The table row number.
+     */
+    public function sync_job_in_row_should_be_enabled(string $rownumber): void {
+        $this->assert_sync_job_in_row_status($rownumber, true);
+    }
+
+    /**
+     * Asserts that the sync job on the given table row is enabled.
+     *
+     * @Then /^the sync job in row (\d+) should be disabled/
+     * @param string $rownumber The table row number.
+     */
+    public function sync_job_in_row_should_be_disabled(string $rownumber): void {
+        $this->assert_sync_job_in_row_status($rownumber, false);
+    }
+
+    /**
+     * Disable the sync job in the given table row.
+     *
+     * @Then /^I toggle the sync job status in row (\d+)$/
+     * @param string $rownumber The table row number.
+     */
+    public function toggle_sync_job_in_row(string $rownumber): void {
+
+        $xpath = $this->get_xpath_to_status_action_for_sync_job_in_row($rownumber);
+        $params = [$xpath, "xpath_element"];
+        $this->execute("behat_general::i_click_on", $params);
+    }
+
+    /**
+     * Delete the sync job in the given table row.
+     *
+     * @Then /^I delete the sync job in row (\d+)$/
+     * @param string $rownumber The table row number.
+     */
+    public function delete_sync_job_in_row(string $rownumber): void {
+        $xpath = $this->get_xpath_to_delete_action_for_sync_job_in_row($rownumber);
+        $params = [$xpath, "xpath_element"];
+        $this->execute("behat_general::i_click_on", $params);
+    }
+
+    /**
+     * Asserts that the sync job has the given status in the given row.
+     * @param string $rownumber The table row number.
+     * @param bool $enabled The sync job status. TRUE if enabled, FALSE if disabled.
+     * @return void
+     * @throws Exception
+     */
+    protected function assert_sync_job_in_row_status(string $rownumber, bool $enabled): void {
+        $arialabel = $enabled ? "Disable" : "Enable";
+        $xpath = $this->get_xpath_to_status_action_for_sync_job_in_row($rownumber);
+        $xpath .= "/i[contains(@aria-label, '$arialabel')]";
+        $params = [$xpath, "xpath_element"];
+        $this->execute("behat_general::should_exist", $params);
+    }
+
+    /**
+     * Returns the xpath selector to the status action element in a given table row.
+     *
+     * @param string $rownumber The table row number.
+     * @return string The xpath selector.
+     */
+    protected function get_xpath_to_status_action_for_sync_job_in_row(string $rownumber): string {
+        $xpath = $this->get_xpath_to_action_cell_for_sync_job_in_row($rownumber);
+        $xpath .= '/a[1]';
+        return $xpath;
+    }
+
+    /**
+     * Returns the xpath selector to the delete action element in a given table row.
+     *
+     * @param string $rownumber The table row number.
+     * @return string The xpath selector.
+     */
+    protected function get_xpath_to_delete_action_for_sync_job_in_row(string $rownumber): string {
+        $xpath = $this->get_xpath_to_action_cell_for_sync_job_in_row($rownumber);
+        $xpath .= '/a[2]';
+        return $xpath;
+    }
+
+    /**
+     * Returns the xpath selector to the table cell containing the action elements in a given table row.
+     *
+     * @param string $rownumber The table row number.
+     * @return string The xpath selector.
+     */
+    protected function get_xpath_to_action_cell_for_sync_job_in_row(string $rownumber): string {
+        $xpath = '//table[contains(@class, "tool-ilioscategoryassignment-sync-jobs")]';
+        $xpath .= '/tbody';
+        $xpath .= "/tr[$rownumber]";
+        $xpath .= '/td[4]';
+        return $xpath;
+    }
+}

--- a/tests/behat/management.feature
+++ b/tests/behat/management.feature
@@ -1,0 +1,89 @@
+@tool @tool_ilioscategoryassignment @tool_ilioscategoryassignment_management
+Feature: Sync job management
+  In order to manage Ilios category user assignments
+  As an admin
+  I want to create, view, and delete category sync jobs.
+
+  Background:
+    Given I log in as "admin"
+    And the following config values are set as admin:
+      | host_url                   | http://ilios.demo | tool_ilioscategoryassignment |
+      | ilios_mock_backend_enabled | 1                 | tool_ilioscategoryassignment |
+    And a valid Ilios API access token has been configured for tool_ilioscategoryassignment
+
+  Scenario: View list sync jobs
+    Given the following "tool_ilioscategoryassignment > sync jobs" exist:
+      | title    | schoolid | coursecatid | role          | enabled |
+      | SoM sync | 1        | 1           | manager       | 1       |
+      | SoP sync | 2        | 1           | coursecreator | 0       |
+    When I navigate to "Plugins > Admin tools" in site administration
+    And I follow "Category: Ilios category assignment"
+    And I follow "Sync jobs"
+    Then the following should exist in the "tool-ilioscategoryassignment-sync-jobs" table:
+      | Title      | Course category | Role           | Ilios school |
+      | SoM sync   | Category 1      | Manager        | Medicine     |
+      | SoP sync   | Category 1      | Course creator | Pharmacy     |
+    And the sync job in row 1 should be enabled
+    And the sync job in row 2 should be disabled
+
+  Scenario: Toggle sync job status
+    Given the following "tool_ilioscategoryassignment > sync jobs" exist:
+      | title    | schoolid | coursecatid | role          | enabled |
+      | SoM sync | 1        | 1           | manager       | 1       |
+    When I navigate to "Plugins > Admin tools" in site administration
+    And I follow "Category: Ilios category assignment"
+    And I follow "Sync jobs"
+    Then the following should exist in the "tool-ilioscategoryassignment-sync-jobs" table:
+      | Title      | Course category | Role           | Ilios school |
+      | SoM sync   | Category 1      | Manager        | Medicine     |
+    And the sync job in row 1 should be enabled
+    When I toggle the sync job status in row 1
+    Then the sync job in row 1 should be disabled
+    When I toggle the sync job status in row 1
+    Then the sync job in row 1 should be enabled
+
+  Scenario: Delete a sync job
+    Given the following "tool_ilioscategoryassignment > sync jobs" exist:
+      | title    | schoolid | coursecatid | role          |
+      | SoM sync | 1        | 1           | manager       |
+      | SoP sync | 2        | 1           | coursecreator |
+    When I navigate to "Plugins > Admin tools" in site administration
+    And I follow "Category: Ilios category assignment"
+    And I follow "Sync jobs"
+    Then the following should exist in the "tool-ilioscategoryassignment-sync-jobs" table:
+      | Title      | Course category | Role           | Ilios school |
+      | SoM sync   | Category 1      | Manager        | Medicine     |
+      | SoP sync   | Category 1      | Course creator | Pharmacy     |
+    When I delete the sync job in row 1
+    And I press "Delete"
+    Then the following should exist in the "tool-ilioscategoryassignment-sync-jobs" table:
+      | SoP sync   | Category 1      | Course creator | Pharmacy     |
+    And the following should not exist in the "tool-ilioscategoryassignment-sync-jobs" table:
+      | SoM sync   | Category 1      | Manager        | Medicine     |
+
+  Scenario: Create sync jobs
+    When I navigate to "Plugins > Admin tools" in site administration
+    And I follow "Category: Ilios category assignment"
+    And I follow "New sync job"
+    And I set the following fields to these values:
+    | Title               | SoM sync   |
+    | Select category     | Category 1 |
+    | Select role         | Manager    |
+    | Select Ilios school | Medicine   |
+    And I press "Submit"
+    Then the following should exist in the "tool-ilioscategoryassignment-sync-jobs" table:
+      | Title      | Course category | Role           | Ilios school |
+      | SoM sync   | Category 1      | Manager        | Medicine     |
+    When I navigate to "Plugins > Admin tools" in site administration
+    And I follow "Category: Ilios category assignment"
+    And I follow "New sync job"
+    And I set the following fields to these values:
+      | Title               | SoP sync       |
+      | Select category     | Category 1     |
+      | Select role         | Course creator |
+      | Select Ilios school | Pharmacy       |
+    And I press "Submit"
+    Then the following should exist in the "tool-ilioscategoryassignment-sync-jobs" table:
+      | Title      | Course category | Role           | Ilios school |
+      | SoM sync   | Category 1      | Manager        | Medicine     |
+      | SoP sync   | Category 1      | Course creator | Pharmacy     |

--- a/tests/behat/settings.feature
+++ b/tests/behat/settings.feature
@@ -1,23 +1,39 @@
 @tool @tool_ilioscategoryassignment @tool_ilioscategoryassignment_settings
-Feature: Plugin administration
-  In order to manage category syncs
+Feature: Plugin settings
+  In order to add and update Ilios connection details
   As an admin
-  I want to configure plugin settings and create/update/delete sync instances
+  I want to configure plugin settings
 
   Background:
     Given I log in as "admin"
 
-  Scenario: Links to sync management and settings forms are visible under plugins
+  Scenario: Settings form with default values
     When I select "Site administration" from primary navigation
-    And I select "Plugins" from secondary navigation
-    Then I should see "Ilios category assignment"
-    And I should see "Sync jobs"
-    And I should see "New sync job"
-    And I should see "Ilios API client configuration"
+    And I follow "Ilios API client configuration"
+    Then the following fields match these values:
+      | Host URL      | localhost |
+      | Ilios API key |           |
 
-  Scenario: Links to sync management and settings forms are visible under admin tools
-    Given I navigate to "Plugins > Admin tools" in site administration
-    When I follow "Category: Ilios category assignment"
-    Then I should see "Sync jobs"
-    And I should see "New sync job"
-    And I should see "Ilios API client configuration"
+  Scenario: Settings form with customized values
+    Given the following config values are set as admin:
+      | host_url | http://ilios.demo | tool_ilioscategoryassignment |
+      | apikey   | XXXXXX            | tool_ilioscategoryassignment |
+    When I select "Site administration" from primary navigation
+    And I follow "Ilios API client configuration"
+    Then the following fields match these values:
+      | Host URL      | http://ilios.demo |
+      | Ilios API key | XXXXXX            |
+
+  Scenario: Update settings
+    When I select "Site administration" from primary navigation
+    And I follow "Ilios API client configuration"
+    Then the following fields match these values:
+      | Host URL      | localhost |
+      | Ilios API key |           |
+    When I set the following fields to these values:
+      | Host URL      | http://ilios.demo |
+      | Ilios API key | XXXXXX            |
+    And I press "Save changes"
+    Then the following fields match these values:
+      | Host URL      | http://ilios.demo |
+      | Ilios API key | XXXXXX            |

--- a/tests/generator/behat_tool_ilioscategoryassignment_generator.php
+++ b/tests/generator/behat_tool_ilioscategoryassignment_generator.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+/**
+ * Behat data generator for tool_ilioscategoryassignment.
+ *
+ * @category   test
+ * @package    tool_ilioscategoryassignment
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_tool_ilioscategoryassignment_generator extends behat_generator_base {
+
+    /**
+     * Get the list of creatable entities for tool_ilioscategoryassignment.
+     *
+     * @return array
+     */
+    protected function get_creatable_entities(): array {
+        return [
+            'sync jobs' => [
+                'singular' => 'sync job',
+                'datagenerator' => 'sync_job',
+                'required' => [
+                    'title',
+                    'schoolid',
+                    'coursecatid',
+                    'role',
+                ],
+                'switchids' => ['role' => 'roleid'],
+            ],
+        ];
+    }
+}

--- a/tests/ilios_test.php
+++ b/tests/ilios_test.php
@@ -34,7 +34,6 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use moodle_exception;
-use Psr\Http\Message\RequestInterface;
 use tool_ilioscategoryassignment\tests\helper;
 
 /**


### PR DESCRIPTION
this iterates on the acceptance tests introduced in #32 and takes this to the next level - by subbing in a mocked Ilios backend via a [custom guzzle handler ](https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html#handlers ) during Behat runs.
which enabled us to put the entire administrative and settings UI for this plugin under test coverage.