### PR TITLE
declare fkey constraint the correct way.

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -87,10 +87,15 @@ function xmldb_tool_ilioscategoryassignment_upgrade($oldversion): bool {
     }
 
     if ($oldversion < 2024102301) {
-        $tablename = 'tool_ilioscategoryassignment';
-        $table = new xmldb_table($tablename);
+        // Adds fkey/index that did not stick during a previous migration.
+        $table = new xmldb_table('tool_ilioscategoryassignment');
         $key = new xmldb_key('usermodified', XMLDB_KEY_FOREIGN, ['usermodified'], 'user', ['id']);
         $dbman->add_key($table, $key);
+
+        // Undo the 0 default value on schoolid - it's not in the schema definition, and it's not needed.
+        $field = new xmldb_field('schoolid', XMLDB_TYPE_INTEGER, '10', null, true, null, null, 'title');
+        $dbman->change_field_default($table, $field);
+
         upgrade_plugin_savepoint(true, 2024102301, 'tool', 'ilioscategoryassignment');
     }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -83,9 +83,15 @@ function xmldb_tool_ilioscategoryassignment_upgrade($oldversion): bool {
             $DB->update_record($tablename, $job);
         }
 
-        $table->add_key('usermodified', XMLDB_KEY_FOREIGN, ['usermodified'], 'user', ['id']);
-
         upgrade_plugin_savepoint(true, 2024080600, 'tool', 'ilioscategoryassignment');
+    }
+
+    if ($oldversion < 2024102301) {
+        $tablename = 'tool_ilioscategoryassignment';
+        $table = new xmldb_table($tablename);
+        $key = new xmldb_key('usermodified', XMLDB_KEY_FOREIGN, ['usermodified'], 'user', ['id']);
+        $dbman->add_key($table, $key);
+        upgrade_plugin_savepoint(true, 2024102301, 'tool', 'ilioscategoryassignment');
     }
 
     return true;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102300;       // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102301;       // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2024041600;       // Requires this Moodle version.
 $plugin->component = 'tool_ilioscategoryassignment';     // Full name of the plugin (used for diagnostics).
 $plugin->release = 'v4.4';


### PR DESCRIPTION
xmldb_table::add_key() doesn't work on upgrading existing tables. remove this function call from the previous migration, and add a new migration/version bump that correctly adds the constraint. (refs #34)

we also had a mismatch between upgrade script and schema definition - the school value was defaulted to `0` if that column was added via the upgrade script, but the schema definition declares the no default value, which then defaults to  `NULL`. (refs #37)