### PR TITLE
clean up linting errors and fix test failure.

### DIFF
--- a/classes/eventobservers.php
+++ b/classes/eventobservers.php
@@ -53,5 +53,3 @@ class eventobservers {
         }
     }
 }
-
-

--- a/classes/form/create_sync_job.php
+++ b/classes/form/create_sync_job.php
@@ -100,8 +100,12 @@ class create_sync_job extends moodleform {
         $mform->addElement('select', 'roleid', get_string('selectrole', 'tool_ilioscategoryassignment'), $roleoptions);
         $mform->addRule('roleid', null, 'required', null, 'client');
 
-        $mform->addElement('select', 'iliosschoolid', get_string('selectiliosschool', 'tool_ilioscategoryassignment'),
-            $iliosschools);
+        $mform->addElement(
+            'select',
+            'iliosschoolid',
+            get_string('selectiliosschool', 'tool_ilioscategoryassignment'),
+            $iliosschools
+        );
         $mform->addRule('iliosschoolid', null, 'required', null, 'client');
 
         $this->add_action_buttons(false, get_string('submit'));

--- a/classes/ilios.php
+++ b/classes/ilios.php
@@ -38,7 +38,6 @@ use moodle_exception;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ilios {
-
     /**
      * @var string The API base path.
      */

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -82,7 +82,7 @@ class renderer extends plugin_renderer_base {
             $coursecatcell = new html_table_cell($coursetitle);
 
             $roleid = $job->get('roleid');
-            $roletitle = get_string('notfound', 'tool_ilioscategoryassignment',  $job->get('roleid'));
+            $roletitle = get_string('notfound', 'tool_ilioscategoryassignment', $job->get('roleid'));
             if (array_key_exists($roleid, $roles)) {
                 $roletitle = $roles[$roleid]->localname;
             }
@@ -99,21 +99,27 @@ class renderer extends plugin_renderer_base {
             $actions = [];
             if ($job->get('enabled')) {
                 $actions[] = $this->action_icon(
-                    new moodle_url("$CFG->wwwroot/$CFG->admin/tool/ilioscategoryassignment/index.php",
-                        ['job_id' => $job->get('id'), 'action' => 'disable', 'sesskey' => sesskey()]),
+                    new moodle_url(
+                        "$CFG->wwwroot/$CFG->admin/tool/ilioscategoryassignment/index.php",
+                        ['job_id' => $job->get('id'), 'action' => 'disable', 'sesskey' => sesskey()]
+                    ),
                     new pix_icon('t/hide', new lang_string('disable'))
                 );
             } else {
                 $actions[] = $this->action_icon(
-                    new moodle_url("$CFG->wwwroot/$CFG->admin/tool/ilioscategoryassignment/index.php",
-                        ['job_id' => $job->get('id'), 'action' => 'enable', 'sesskey' => sesskey()]),
+                    new moodle_url(
+                        "$CFG->wwwroot/$CFG->admin/tool/ilioscategoryassignment/index.php",
+                        ['job_id' => $job->get('id'), 'action' => 'enable', 'sesskey' => sesskey()]
+                    ),
                     new pix_icon('t/show', new lang_string('enable'))
                 );
             }
 
             $actions[] = $this->action_icon(
-                new moodle_url("$CFG->wwwroot/$CFG->admin/tool/ilioscategoryassignment/index.php",
-                    ['job_id' => $job->get('id'), 'action' => 'delete', 'sesskey' => sesskey()]),
+                new moodle_url(
+                    "$CFG->wwwroot/$CFG->admin/tool/ilioscategoryassignment/index.php",
+                    ['job_id' => $job->get('id'), 'action' => 'delete', 'sesskey' => sesskey()]
+                ),
                 new pix_icon('t/delete', new lang_string('delete'))
             );
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -42,8 +42,6 @@ use core_privacy\local\request\userlist;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements core_userlist_provider, data_provider, metadata_provider {
-
-
     /**
      * Returns the metadata for the user data stored in this plugin.
      *

--- a/classes/sync_job.php
+++ b/classes/sync_job.php
@@ -41,7 +41,6 @@ require_once($CFG->libdir . '/accesslib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class sync_job extends persistent {
-
     /**
      * @var string The sync job database table name.
      */

--- a/classes/task/sync_task.php
+++ b/classes/task/sync_task.php
@@ -25,7 +25,6 @@
 namespace tool_ilioscategoryassignment\task;
 
 use coding_exception;
-
 use core\task\scheduled_task;
 use core_course_category;
 use dml_exception;
@@ -139,7 +138,7 @@ class sync_task extends scheduled_task {
         }
 
         // Filter out any users that do not fulfill a director or instructor function in ilios.
-        $records = array_filter($records, function(stdClass $rec) {
+        $records = array_filter($records, function (stdClass $rec) {
             return ! empty($rec->directedCourses) ||
                    ! empty($rec->directedPrograms) ||
                    ! empty($rec->directedSchools) ||
@@ -150,7 +149,8 @@ class sync_task extends scheduled_task {
         });
 
         foreach ($records as $rec) {
-            if (object_property_exists($rec, 'campusId')
+            if (
+                object_property_exists($rec, 'campusId')
                 && '' !== trim($rec->campusId)
             ) {
                 $iliosusers[] = $rec->campusId;
@@ -173,7 +173,7 @@ class sync_task extends scheduled_task {
         if (empty($iliosusers)) {
             return [];
         }
-        list($insql, $params) = $DB->get_in_or_equal($iliosusers);
+        [$insql, $params] = $DB->get_in_or_equal($iliosusers);
         $sql = "SELECT * FROM {user} WHERE idnumber $insql";
         $users = $DB->get_records_sql($sql, $params);
         if (count($users) < count($iliosusers)) {
@@ -209,7 +209,7 @@ class sync_task extends scheduled_task {
 
         // Filter out any role assignments that weren't made by this plugin.
         $roleassignments = array_values(
-            array_filter($roleassignments, function($role) {
+            array_filter($roleassignments, function ($role) {
                 return $role->component === 'tool_ilioscategoryassignment';
             })
         );
@@ -251,7 +251,6 @@ class sync_task extends scheduled_task {
                 $unassignmentcounter++;
             }
             mtrace("Un-assigned $unassignmentcounter user(s) from category.");
-
         }
         mtrace("Finished syncing course category '$formattedcategoryname'.");
     }

--- a/classes/tests/helper.php
+++ b/classes/tests/helper.php
@@ -37,7 +37,6 @@ use Firebase\JWT\JWT;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class helper {
-
     /**
      * Generates an un-expired JWT, to be used as access token.
      * This token will pass client-side token validation.

--- a/classes/tests/ilios_backend.php
+++ b/classes/tests/ilios_backend.php
@@ -38,7 +38,6 @@ use Psr\Http\Message\ResponseInterface;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ilios_backend {
-
     /**
      * @var array A list of mock Ilios school data.
      */
@@ -64,7 +63,7 @@ class ilios_backend {
         $path = $uri->getPath();
 
         // Route by path.
-        $response = match($path) {
+        $response = match ($path) {
             '/api/v3/schools' => $this->get_all_schools_response(),
             default => new Response(500),
         };

--- a/create.php
+++ b/create.php
@@ -66,6 +66,3 @@ if ($data) {
     $mform->display();
     echo $OUTPUT->footer();
 }
-
-
-

--- a/settings.php
+++ b/settings.php
@@ -27,7 +27,8 @@ defined('MOODLE_INTERNAL') || die();
 if ($hassiteconfig) {
     $ADMIN->add('tools', new admin_category(
         'ilioscategoryassignment',
-        get_string('pluginname', 'tool_ilioscategoryassignment')));
+        get_string('pluginname', 'tool_ilioscategoryassignment')
+    ));
 
     // Sync jobs admin page.
     $ADMIN->add('ilioscategoryassignment', new admin_externalpage(
@@ -52,16 +53,25 @@ if ($hassiteconfig) {
         'moodle/site:config'
     );
 
-    $settings->add(new admin_setting_heading('tool_ilioscategoryassignment_settings', '',
-        get_string('clientconfig_desc', 'tool_ilioscategoryassignment')));
+    $settings->add(new admin_setting_heading(
+        'tool_ilioscategoryassignment_settings',
+        '',
+        get_string('clientconfig_desc', 'tool_ilioscategoryassignment')
+    ));
 
     if (!during_initial_install()) {
-        $settings->add(new admin_setting_configtext('tool_ilioscategoryassignment/host_url',
+        $settings->add(new admin_setting_configtext(
+            'tool_ilioscategoryassignment/host_url',
             get_string('host_url', 'tool_ilioscategoryassignment'),
-            get_string('host_url_desc', 'tool_ilioscategoryassignment'), 'localhost'));
-        $settings->add(new admin_setting_configtext('tool_ilioscategoryassignment/apikey',
+            get_string('host_url_desc', 'tool_ilioscategoryassignment'),
+            'localhost'
+        ));
+        $settings->add(new admin_setting_configtext(
+            'tool_ilioscategoryassignment/apikey',
             get_string('apikey', 'tool_ilioscategoryassignment'),
-            get_string('apikey_desc', 'tool_ilioscategoryassignment'), ''));
+            get_string('apikey_desc', 'tool_ilioscategoryassignment'),
+            ''
+        ));
     }
 
     $ADMIN->add('ilioscategoryassignment', $settings);

--- a/tests/behat/behat_tool_ilioscategoryassignment_behat_base.php
+++ b/tests/behat/behat_tool_ilioscategoryassignment_behat_base.php
@@ -24,7 +24,7 @@
 
 use tool_ilioscategoryassignment\tests\helper;
 
-require_once(__DIR__.'/../../../../../lib/behat/behat_base.php');
+require_once(__DIR__ . '/../../../../../lib/behat/behat_base.php');
 
 
 /**
@@ -35,7 +35,6 @@ require_once(__DIR__.'/../../../../../lib/behat/behat_base.php');
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_tool_ilioscategoryassignment_behat_base extends behat_base {
-
     /**
      * Create and store a valid API access token in the plugin configuration.
      *

--- a/tests/behat/behat_tool_ilioscategoryassignment_behat_base.php
+++ b/tests/behat/behat_tool_ilioscategoryassignment_behat_base.php
@@ -100,7 +100,7 @@ class behat_tool_ilioscategoryassignment_behat_base extends behat_base {
     protected function assert_sync_job_in_row_status(string $rownumber, bool $enabled): void {
         $arialabel = $enabled ? "Disable" : "Enable";
         $xpath = $this->get_xpath_to_status_action_for_sync_job_in_row($rownumber);
-        $xpath .= "/i[contains(@aria-label, '$arialabel')]";
+        $xpath .= "[contains(@aria-label, '$arialabel')]";
         $params = [$xpath, "xpath_element"];
         $this->execute("behat_general::should_exist", $params);
     }

--- a/tests/generator/behat_tool_ilioscategoryassignment_generator.php
+++ b/tests/generator/behat_tool_ilioscategoryassignment_generator.php
@@ -25,7 +25,6 @@ declare(strict_types=1);
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_tool_ilioscategoryassignment_generator extends behat_generator_base {
-
     /**
      * Get the list of creatable entities for tool_ilioscategoryassignment.
      *

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -39,7 +39,6 @@ require_once($CFG->libdir . '/grade/grade_scale.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_ilioscategoryassignment_generator extends component_generator_base {
-
     /** @var int Number of created sync jobs. */
     protected int $syncjobcount = 0;
 

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -38,7 +38,6 @@ use coding_exception;
  * @covers     \tool_ilioscategoryassignment_generator
  */
 final class generator_test extends advanced_testcase {
-
     /**
      * Tests sync job generator.
      * @return void
@@ -87,4 +86,3 @@ final class generator_test extends advanced_testcase {
         $this->assertEquals('Sync job 4', $syncjob->get('title'));
     }
 }
-

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -39,7 +39,6 @@ use tool_ilioscategoryassignment\tests\helper;
  * @covers     \tool_ilioscategoryassignment\tests\helper
  */
 final class helper_test extends basic_testcase {
-
     /**
      * Checks that the generator function creates a valid access token.
      * @return void

--- a/tests/ilios_test.php
+++ b/tests/ilios_test.php
@@ -46,7 +46,6 @@ use tool_ilioscategoryassignment\tests\helper;
  * @covers     \tool_ilioscategoryassignment\ilios
  */
 final class ilios_test extends advanced_testcase {
-
     /**
      * Tests the happy path on get_schools().
      *
@@ -112,10 +111,10 @@ final class ilios_test extends advanced_testcase {
         $ilios = di::get(ilios::class);
         $users = $ilios->get_enabled_users_in_school($schoolid);
 
-        $this->assertEquals('/api/v3/users',  $container[0]['request']->getUri()->getPath());
+        $this->assertEquals('/api/v3/users', $container[0]['request']->getUri()->getPath());
         $this->assertEquals(
             "filters[enabled]=true&filters[school]={$schoolid}",
-            urldecode( $container[0]['request']->getUri()->getQuery())
+            urldecode($container[0]['request']->getUri()->getQuery())
         );
         $this->assertCount(2, $users);
         $this->assertEquals(1, $users[0]->id);

--- a/tests/sync_job_test.php
+++ b/tests/sync_job_test.php
@@ -39,7 +39,6 @@ use moodle_exception;
  * @covers     \tool_ilioscategoryassignment\sync_job
  */
 final class sync_job_test extends advanced_testcase {
-
     /**
      * Checks that sync_job::get_course_category() works as intended.
      *

--- a/tests/task/sync_task_test.php
+++ b/tests/task/sync_task_test.php
@@ -50,7 +50,6 @@ use tool_ilioscategoryassignment\tests\helper;
  * @covers     \tool_ilioscategoryassignment\task\sync_task
  */
 final class sync_task_test extends advanced_testcase {
-
     /**
      * Tests task execution, checks that category role assignment/unassignment works as intended.
      * @return void


### PR DESCRIPTION
moodle-plugin-ci has updated its phpcs config rules. these changes realign our plugin code with the linting rules.

auto-fixed via `phpcbf`. no functional changes.

while at it - i also fixed #39.
this has to go in with the linting fixes, separate PRs would fail in the CI individually.